### PR TITLE
fix: critical bug in wp-content detection with set -e

### DIFF
--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -354,9 +354,9 @@ Please verify this is a valid Duplicator backup archive."
   local best_dir="" best_score=0
   for dir in "${candidates[@]}"; do
     local score=0
-    [[ -d "$dir/plugins" ]] && ((score++))
-    [[ -d "$dir/themes" ]] && ((score++))
-    [[ -d "$dir/uploads" ]] && ((score++))
+    [[ -d "$dir/plugins" ]] && score=$((score + 1))
+    [[ -d "$dir/themes" ]] && score=$((score + 1))
+    [[ -d "$dir/uploads" ]] && score=$((score + 1))
 
     if [[ $score -gt $best_score ]]; then
       best_score=$score


### PR DESCRIPTION
## Summary
**CRITICAL HOTFIX:** Fix Duplicator mode completely failing due to arithmetic expansion incompatibility with `set -e`.

## The Bug
Duplicator mode would stop immediately after finding the database file and never proceed to wp-content detection, maintenance mode, or any actual migration work.

**User Impact:**
- 🚨 Duplicator mode was **completely broken** for all users
- Script silently failed with no error message
- Last log entry: "Found database file" then script exits
- Extraction directory kept for "debugging" (exit cleanup triggered)

## Root Cause

The script uses `set -Eeuo pipefail` for strict error handling. The wp-content scoring logic used `((score++))` which has a critical interaction with `set -e`:

```bash
local score=0
((score++))  # Returns 0 (pre-increment value)
             # Bash interprets 0 as "false"
             # set -e sees "false" and exits immediately!
```

**The Problem Chain:**
1. `((score++))` returns the value **before** incrementing (0 when score=0)
2. In bash, exit code 0 means false/failure in conditional contexts
3. `set -e` exits the script on any "false" command
4. Script stops dead with no error message

## The Fix

Changed from `((score++))` to `score=$((score + 1))`:

```bash
# Before (BROKEN):
[[ -d "$dir/plugins" ]] && ((score++))

# After (FIXED):
[[ -d "$dir/plugins" ]] && score=$((score + 1))
```

The assignment form always succeeds (exit code 0 = success), making it compatible with `set -e`.

## Why This Wasn't Caught Earlier

- ✅ ShellCheck doesn't flag this (it's valid bash)
- ✅ Test suite doesn't test Duplicator mode with actual archives
- ✅ Works fine WITHOUT `set -e` (most bash scripts don't use strict mode)
- ❌ Only manifests when: strict mode + arithmetic on zero + conditional execution

## Testing

**Verified the fix:**
```bash
# Simulated exact script conditions with set -e
bash -c 'set -e; score=0; [[ true ]] && score=$((score + 1)); echo "Success: $score"'
# Output: Success: 1

# Old broken version:
bash -c 'set -e; score=0; [[ true ]] && ((score++)); echo "Success: $score"'
# Output: (nothing - script exits immediately)
```

**Additional testing:**
- ✅ ShellCheck passes with zero warnings
- ✅ All 11 automated tests pass
- ✅ Arithmetic result identical to before
- ✅ Compatible with set -e

## Impact

**Severity:** CRITICAL - Duplicator mode was non-functional  
**Affected:** All v1.1.0 users attempting Duplicator imports  
**Fix Priority:** Immediate hotfix required  

## Recommendation

1. Merge this PR immediately
2. Create v1.1.1 patch release
3. Consider adding integration test with real Duplicator archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)