### PR TITLE
fix: reset database before import in duplicator mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2025-10-09
+### Fixed
+- Fixed duplicate primary key errors in Duplicator mode by resetting database before import. Duplicator SQL dumps contain INSERT statements that conflict with existing destination data.
+
 ## [1.1.2] - 2025-10-09
 ### Fixed
 - Excluded `object-cache.php` from wp-content transfers in both push and Duplicator modes to prevent fatal errors when source site uses caching infrastructure (Redis, Memcache, etc.) not available on destination server.

--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -1101,6 +1101,7 @@ fi
 
 # Phase 7: Import database
 if $DRY_RUN; then
+  log "[dry-run] Would reset database to clean state"
   log "[dry-run] Would import database from: $(basename "$DUPLICATOR_DB_FILE")"
   log "[dry-run] Would detect and align table prefix if needed"
 else
@@ -1109,6 +1110,11 @@ else
   # Get current destination prefix before import
   DEST_DB_PREFIX_BEFORE="$(wp_local db prefix)"
   log "Current wp-config.php table prefix: $DEST_DB_PREFIX_BEFORE"
+
+  # Reset database to clean state to prevent duplicate key errors
+  log "Resetting database to clean state..."
+  wp_local db reset --yes
+  log "Database reset complete"
 
   # Import the database
   wp_local db import "$DUPLICATOR_DB_FILE"


### PR DESCRIPTION
## Summary

Fixes duplicate primary key errors (ERROR 1062) when importing Duplicator archives by resetting the destination database before import.

## Problem

User reported errors during Duplicator import:
```
ERROR 1062 (23000) at line 16184: Duplicate entry '2588' for key 'PRIMARY'
ERROR 1062 (23000) at line 16185: Duplicate entry '2589' for key 'PRIMARY'
ERROR 1062 (23000) at line 16186: Duplicate entry '2590' for key 'PRIMARY'
...
```

**Root cause:** Duplicator SQL dumps contain `INSERT` statements that expect a clean/empty database. The script was importing on top of existing destination data, causing primary key conflicts.

## Solution

Reset the destination database before importing to ensure a clean slate:
```bash
wp db reset --yes
wp db import "$DUPLICATOR_DB_FILE"
```

This matches the behavior of Duplicator's own installer.

## Changes

**wp-migrate.sh:**
- Line 1114-1117: Added `wp db reset --yes` before database import
- Line 1104: Added dry-run logging for reset step

**CHANGELOG.md:**
- Added v1.1.3 release entry

## Safety

- ✅ Database backup already created before this phase (Phase 5)
- ✅ Rollback instructions include restoring database backup
- ✅ This is the intended behavior for Duplicator mode (complete replacement)

## Testing

- ✅ ShellCheck passes
- ✅ All 11 tests pass
- ✅ User confirmed ERROR 1062 on multiple tables

## Versioning

This is v1.1.3 - patch release fixing duplicate key errors in Duplicator mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)