### PR TITLE
chore: prepare v1.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.6] - 2025-10-10
 ### Added
-- Added `--stellarsites` flag for Duplicator mode to handle managed hosts with protected mu-plugins directories. When enabled, excludes `mu-plugins/` directory from rsync, preserving protected host mu-plugins while still using `--delete` to ensure a clean migration of all other wp-content files.
+- Added `--stellarsites` flag for Duplicator mode to handle managed hosts with protected mu-plugins directories. When enabled, uses root-anchored rsync exclusions (`/mu-plugins/`, `/mu-plugins.php`, `/object-cache.php`) to preserve host-specific files at wp-content root while still using `--delete` to ensure a clean migration of all other files. This prevents silent data loss from unanchored patterns while maintaining compatibility with StellarSites and similar managed hosting.
 
 ## [1.1.5] - 2025-10-09
 ### Fixed


### PR DESCRIPTION
Updates CHANGELOG.md for v1.1.6 release.

## Changes
- Moved [Unreleased] items to [1.1.6] section
- Added date: 2025-10-10
- Updated description to include root-anchored rsync exclusions detail

This PR is part of the release workflow before tagging v1.1.6.