### PR TITLE
chore: update CHANGELOG for v1.1.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.8] - 2025-10-10
 ### Fixed
-- Improved non-critical error handling to prevent script abortion during cleanup operations. Maintenance mode disable failures, temporary directory cleanup failures, and cache flush failures now log colored warnings (yellow) but allow the script to complete successfully. This prevents migration success from being blocked by non-essential cleanup tasks.
+- Improved non-critical error handling to prevent script abortion during cleanup operations. Maintenance mode disable failures, temporary directory cleanup failures, and cache flush failures now log colored warnings (yellow) but allow the script to complete successfully. This prevents migration success from being blocked by non-essential cleanup tasks. Log files remain clean (no ANSI color codes) for readability and tooling compatibility.
 
 ## [1.1.7] - 2025-10-10
 ### Fixed


### PR DESCRIPTION
## Summary

Moves [Unreleased] changes to [1.1.8] version section in CHANGELOG.md.

## Changes

- Non-critical error handling improvements
- Colored warnings (yellow) for cleanup failures
- Clean log files (no ANSI codes)

Ready for v1.1.8 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)