### PR TITLE
chore: add CODEOWNERS and enforce PR approval workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,229 +1,166 @@
 {
-  "systemPrompt": "You are working on wp-migrate.sh, a WordPress migration bash script that pushes wp-content and database exports from source to destination servers.\n\nCRITICAL WORKFLOW ENFORCEMENT:\nBefore ANY git operation (branch, commit, push, PR), you MUST:\n1. Ask the user: 'Are you working on v1.x.x maintenance (main) or v2.0.0 development (v2)?'\n2. Read and reference the appropriate workflow (workflow_v1 or workflow_v2) from this settings file\n3. State which workflow step you're executing (e.g., 'V1 Step 7: Pushing feature branch to main')\n4. Verify branch naming matches target (v2-* branches MUST target v2, others target main)\n5. Check the project follows ShellCheck standards (script is currently ShellCheck-clean)\n\nIf you cannot confirm all 5 items above, STOP and ask the user for clarification.\n\nIMPORTANT: Before starting ANY work, ALWAYS:\n- Ask which version (v1 or v2) the user wants to work on\n- Read project documentation (README.md, CHANGELOG.md)\n- Understand the full scope before making changes\n- Follow the correct workflow for the target version\n\nKey Requirements:\n- v1 work: branch from main → PR to main (production stable)\n- v2 work: branch from v2 → PR to v2 (major refactor, NOT ready for production)\n- NEVER merge v2-* branches directly to main\n- NEVER push directly to main or v2 - ALL merges via GitHub PRs\n- Update CHANGELOG.md in [Unreleased] section for ALL changes (both v1 and v2)\n- Maintain ShellCheck-clean code\n- Use conventional commit messages (feat:, fix:, test:, docs:, chore:, refactor:)",
-
-  "versionContext": {
-    "description": "ALWAYS ask user at session start: 'Working on v1 or v2?'",
-    "v1": {
-      "branch": "main",
-      "purpose": "Production stable releases (v1.x.x)",
-      "status": "Active maintenance - bug fixes and minor features only",
-      "releases": "Tagged and released immediately after merge",
-      "userFacing": true
-    },
-    "v2": {
-      "branch": "v2",
-      "purpose": "Major refactor: modularize codebase, add build system",
-      "status": "Development in progress - NOT production ready",
-      "releases": "No releases until v2 branch merges to main",
-      "userFacing": false,
-      "warning": "v2-* branches must NEVER be merged directly to main"
-    }
-  },
-
-  "customInstructions": {
-    "beforeStarting": [
-      "🚨 CRITICAL: Ask user 'Are you working on v1 (main) or v2 (v2 branch)?'",
-      "Read project documentation (README.md, CHANGELOG.md)",
-      "Verify you're on the correct branch (main for v1, v2 for v2)",
-      "Understand the full scope before making changes",
-      "Review bash best practices and security (script uses set -Eeuo pipefail)"
-    ],
-    "whileCoding": [
-      "Validate ALL user inputs and command-line arguments",
-      "Follow bash best practices (proper quoting, error handling)",
-      "Maintain ShellCheck-clean code (no warnings)",
-      "Ensure code follows existing script style",
-      "Preserve set -Eeuo pipefail safety flags",
-      "Test with real WordPress installations when possible"
-    ],
-    "beforeCommitting": [
-      "Confirm you're on the correct workflow (v1 or v2)",
-      "Test script with --dry-run mode",
-      "Run shellcheck wp-migrate.sh (must pass with no warnings)",
-      "Update CHANGELOG.md in [Unreleased] section",
-      "Verify changes don't break existing functionality",
-      "Review code for security issues (SSH, file operations, DB handling)"
-    ],
-
-    "workflow_v1": {
-      "description": "For v1.x.x maintenance - bug fixes and minor features",
-      "baseBranch": "main",
-      "steps": [
-        "1. git checkout main && git pull --rebase origin main",
-        "2. git checkout -b <type>/<descriptive-slug>  (e.g., fix/url-validation)",
-        "3. Make changes and test with --dry-run",
-        "4. Run shellcheck wp-migrate.sh",
-        "5. Update CHANGELOG.md [Unreleased] section",
-        "6. git add -A && git commit -m 'type: description'",
-        "7. BEFORE pushing: git fetch origin main && check if main has new commits (git log HEAD..origin/main)",
-        "8. IF main has new commits: git merge origin/main, resolve conflicts, git commit",
-        "9. git push origin <branch-name>",
-        "10. Open PR to main (TARGET: main, NOT v2)",
-        "11. After merge, delete feature branch locally and remotely",
-        "12. User decides if release is needed (you ask, don't assume)"
-      ],
-      "branchPrefixes": ["fix/", "feature/", "chore/", "docs/"],
-      "prTarget": "main",
-      "examples": [
-        "fix/maintenance-mode-cleanup → PR to main → v1.1.9 release",
-        "feature/add-retry-logic → PR to main → v1.2.0 release"
-      ]
-    },
-
-    "workflow_v2": {
-      "description": "For v2.0.0 development - major refactor and new architecture",
-      "baseBranch": "v2",
-      "steps": [
-        "1. git checkout v2 && git pull --rebase origin v2",
-        "2. git checkout -b v2-<type>/<descriptive-slug>  (e.g., v2-feature/modularize)",
-        "3. Make changes and test with --dry-run (if applicable)",
-        "4. Run shellcheck on affected files",
-        "5. Update CHANGELOG.md [Unreleased] section (note it's for v2)",
-        "6. git add -A && git commit -m 'type: description'",
-        "7. BEFORE pushing: git fetch origin v2 && check if v2 has new commits (git log HEAD..origin/v2)",
-        "8. IF v2 has new commits: git merge origin/v2, resolve conflicts, make build, git commit",
-        "9. git push origin <branch-name>",
-        "10. Open PR to v2 branch (TARGET: v2, NOT main) ⚠️",
-        "11. After merge, delete feature branch locally and remotely",
-        "12. NO releases until v2 branch is complete and merged to main"
-      ],
-      "branchPrefixes": ["v2-feature/", "v2-fix/", "v2-chore/", "v2-refactor/", "v2-test/"],
-      "prTarget": "v2",
-      "warning": "⚠️ NEVER create PR from v2-* branches to main. Always target v2 branch.",
-      "examples": [
-        "v2-feature/modularize-core → PR to v2 (NOT main)",
-        "v2-refactor/build-system → PR to v2 (NOT main)",
-        "v2-fix/shellcheck-errors → PR to v2 (NOT main)"
-      ]
-    },
-
-    "multiPrStrategy": {
-      "note": "When multiple PRs are in flight (created but not yet merged):",
-      "problem": "If PR A merges before PR B, PR B's branch is now out of date and may have conflicts",
-      "prevention": [
-        "BEFORE creating any PR: Check if base branch has new commits since branch creation",
-        "BEFORE final push to PR: Sync with latest base branch",
-        "AFTER any PR merges to base: Immediately sync all open PR branches with base"
-      ],
-      "v1_strategy": {
-        "description": "For PRs targeting main branch",
-        "onPrCreation": [
-          "1. git fetch origin main",
-          "2. Check: Are there commits on main since your branch was created?",
-          "3. If yes: git merge origin/main (or rebase if no conflicts expected)",
-          "4. Run make build && git add -A && git commit --amend --no-edit",
-          "5. Then create PR"
-        ],
-        "whenAnotherPrMerges": [
-          "1. git fetch origin main",
-          "2. git merge origin/main (resolve any conflicts)",
-          "3. Run make build to regenerate built files",
-          "4. Run shellcheck to verify",
-          "5. git add -A && git commit -m 'Merge latest main branch'",
-          "6. git push"
-        ]
-      },
-      "v2_strategy": {
-        "description": "For PRs targeting v2 branch",
-        "onPrCreation": [
-          "1. git fetch origin v2",
-          "2. Check: Are there commits on v2 since your branch was created?",
-          "3. If yes: git merge origin/v2 (or rebase if no conflicts expected)",
-          "4. Run make build && git add -A && git commit --amend --no-edit",
-          "5. Then create PR"
-        ],
-        "whenAnotherPrMerges": [
-          "1. git fetch origin v2",
-          "2. git merge origin/v2 (resolve any conflicts)",
-          "3. Run make build to regenerate built files",
-          "4. Run shellcheck to verify",
-          "5. git add -A && git commit -m 'Merge latest v2 branch'",
-          "6. git push"
-        ]
-      },
-      "cross_version": "Keep v1 and v2 PRs completely separate. Do NOT merge v2 work into v1.",
-      "proactiveMonitoring": "After completing work on your PR but BEFORE pushing, ALWAYS run: git fetch origin <base-branch> && git log HEAD..origin/<base-branch> to check if base has moved ahead"
-    },
-
-    "branchTypes": {
-      "v1_branches": {
-        "feature/*": "New features for v1.x.x - PR to main",
-        "fix/*": "Bug fixes for v1.x.x - PR to main",
-        "docs/*": "Documentation updates - PR to main",
-        "chore/*": "Maintenance tasks for v1.x.x - PR to main"
-      },
-      "v2_branches": {
-        "v2-feature/*": "New features for v2.0.0 - PR to v2",
-        "v2-fix/*": "Bug fixes during v2 development - PR to v2",
-        "v2-refactor/*": "Code restructuring for v2.0.0 - PR to v2",
-        "v2-chore/*": "Maintenance tasks for v2.0.0 - PR to v2",
-        "v2-test/*": "Testing infrastructure for v2.0.0 - PR to v2"
-      }
-    }
-  },
+  "systemPrompt": "You are working on wp-migrate.sh, a WordPress migration bash script that pushes wp-content and database exports from source to destination servers.\n\n🚨 CRITICAL PR APPROVAL ENFORCEMENT 🚨\n===========================================\nYOU MUST NEVER MERGE ANY PR WITHOUT EXPLICIT USER APPROVAL.\n\nWhen creating PRs:\n1. Create the PR with 'gh pr create'\n2. IMMEDIATELY STOP and tell user: 'PR #X created at <URL>. Please review and approve before merging.'\n3. WAIT for user to explicitly say 'merge it', 'approve and merge', or 'merge PR #X'\n4. ONLY THEN run 'gh pr merge <number>'\n\nDO NOT:\n- ❌ Create and merge PR in same response\n- ❌ Use 'gh pr create && gh pr merge' chained commands  \n- ❌ Assume user wants immediate merge\n- ❌ Merge because 'it looks ready'\n- ❌ Use '--auto' flag on gh pr merge\n\nBREAKING THIS RULE IS COMPLETELY UNACCEPTABLE.\nUSER MUST APPROVE EVERY PR BEFORE MERGE.\n===========================================\n\nCRITICAL WORKFLOW ENFORCEMENT:\nBefore ANY git operation (branch, commit, push, PR), you MUST:\n1. Read and reference the workflow from this settings file\n2. State which workflow step you're executing (e.g., 'Step 7: Pushing feature branch to main')\n3. Verify branch naming matches conventional prefixes (fix/, feature/, chore/, docs/, refactor/)\n4. Check the project follows ShellCheck standards (script is currently ShellCheck-clean)\n5. For modular source (src/): MUST run 'make build' after changes and commit both source + built files\n\nIf you cannot confirm all 5 items above, STOP and ask the user for clarification.\n\nIMPORTANT: Before starting ANY work, ALWAYS:\n- Read project documentation (README.md, CHANGELOG.md)\n- Understand the full scope before making changes\n- Follow the correct workflow\n\nKey Requirements:\n- All work: branch from main → PR to main → USER APPROVAL → merge\n- NEVER push directly to main - ALL merges via GitHub PRs\n- NEVER merge PRs without explicit user approval (see PR APPROVAL ENFORCEMENT above)\n- For src/ changes: MUST run 'make build' before committing\n- Update CHANGELOG.md in [Unreleased] section for ALL changes\n- Maintain ShellCheck-clean code\n- Use conventional commit messages (feat:, fix:, test:, docs:, chore:, refactor:)",
 
   "projectContext": {
+    "version": "v2.0.0+",
+    "architecture": "Modular source with Makefile build system",
     "stack": "Bash script (requires: wp-cli, rsync, ssh, gzip)",
     "testing": "Manual testing with --dry-run flag + ShellCheck linting",
-    "deployment": "Direct usage - users download and run the script",
+    "deployment": "Direct usage - users download single wp-migrate.sh file",
     "branches": {
       "main": {
-        "purpose": "Production stable (v1.x.x releases)",
-        "protection": "All merges via PR",
+        "purpose": "Production stable releases (v2.0.0+)",
+        "structure": "Modular src/ + built wp-migrate.sh",
+        "protection": "All merges via PR with Code Owner approval",
         "releases": "Immediate - tag after merge",
-        "acceptsFrom": ["fix/*", "feature/*", "chore/*", "docs/*"]
+        "acceptsFrom": ["fix/*", "feature/*", "chore/*", "docs/*", "refactor/*"]
       },
-      "v2": {
-        "purpose": "Development branch for v2.0.0 major refactor",
-        "protection": "All merges via PR",
-        "releases": "None until v2 merges to main",
-        "acceptsFrom": ["v2-feature/*", "v2-fix/*", "v2-refactor/*", "v2-chore/*", "v2-test/*"],
-        "warning": "⚠️ This branch will NOT merge to main until v2.0.0 is complete"
+      "v1-stable": {
+        "purpose": "Archived v1.x codebase (historical reference)",
+        "structure": "Single-file wp-migrate.sh (no src/ directory)",
+        "status": "Read-only - no further development",
+        "note": "Final v1 release was v1.1.8"
       }
     },
     "criticalFiles": [
       "README.md - Complete documentation and usage",
-      "CHANGELOG.md - Keep a Changelog format (track both v1 and v2 changes)",
-      "wp-migrate.sh - Main script (v1 on main, v2 on v2 branch)",
-      ".gitmessage - Commit message template",
-      ".github/pull_request_template.md - PR checklist"
+      "CHANGELOG.md - Keep a Changelog format",
+      "wp-migrate.sh - Built artifact (generated by 'make build')",
+      "wp-migrate.sh.sha256 - Checksum (generated by 'make build')",
+      "src/ - Modular source code (edit these, not wp-migrate.sh)",
+      "Makefile - Build system",
+      ".github/CODEOWNERS - Code ownership for PR approvals",
+      ".githooks/pre-commit - Prevents committing without rebuild"
     ],
-    "testCommand": "shellcheck wp-migrate.sh && ./wp-migrate.sh --help"
+    "testCommand": "make test && ./wp-migrate.sh --help"
   },
 
-  "prTargetValidation": {
-    "description": "Dual-branch workflow - validate PR targets carefully",
-    "rules": {
-      "fix/*": "main",
-      "feature/*": "main",
-      "chore/*": "main",
-      "docs/*": "main",
-      "v2-feature/*": "v2",
-      "v2-fix/*": "v2",
-      "v2-refactor/*": "v2",
-      "v2-chore/*": "v2",
-      "v2-test/*": "v2"
+  "buildSystem": {
+    "description": "v2.0.0+ uses modular source code in src/ with Makefile build",
+    "workflow": [
+      "1. Edit files in src/ directory (NOT wp-migrate.sh directly)",
+      "2. Run 'make build' to regenerate wp-migrate.sh + sha256 checksum",
+      "3. Run 'make test' to verify ShellCheck passes",
+      "4. Commit BOTH source files (src/) AND built files (wp-migrate.sh, .sha256)",
+      "5. Pre-commit hook will prevent committing if build is out of date"
+    ],
+    "makeTargets": {
+      "make build": "Concatenate src/ files into wp-migrate.sh + generate checksum",
+      "make test": "Run shellcheck on built wp-migrate.sh",
+      "make clean": "Remove build artifacts (for testing)",
+      "make help": "Show available targets"
     },
-    "forbidden": [
-      "Direct pushes to main (always use PRs)",
-      "Direct pushes to v2 (always use PRs)",
-      "PRs from v2-* branches to main (MUST target v2 branch)",
-      "PRs from non-v2 branches to v2 (MUST target main)"
-    ],
-    "validation": {
-      "beforeCreatingPR": [
-        "Check branch name prefix",
-        "Verify target branch matches prefix (v2-* → v2, others → main)",
-        "Confirm with user if uncertain",
-        "State target branch explicitly: 'Creating PR from fix/bug to main' or 'Creating PR from v2-feature/x to v2'"
-      ]
-    }
+    "sourceStructure": {
+      "src/header.sh": "Shebang, set flags, default variables",
+      "src/lib/core.sh": "Core utilities (log, err, validate_url)",
+      "src/lib/adapters/": "Archive format adapters (extensible system)",
+      "src/lib/functions.sh": "All other functions",
+      "src/main.sh": "Argument parsing and main execution"
+    },
+    "buildOrder": "header → core → adapters → functions → main",
+    "warnings": [
+      "⚠️ NEVER edit wp-migrate.sh directly (it's generated)",
+      "⚠️ NEVER edit wp-migrate.sh.sha256 directly (it's generated)",
+      "⚠️ ALWAYS run 'make build' after editing src/ files",
+      "⚠️ ALWAYS commit both src/ changes AND built files together"
+    ]
   },
 
-  "autoPrompts": {
-    "description": "Automatic prompts after merge confirmations",
-    "onMainMerge": "✅ PR merged to main successfully (v1.x.x)\n✅ Branch cleaned up\n\n🔍 Next Steps:\n- This is a v1 change - should I create a release tag?\n- Update CHANGELOG.md to move [Unreleased] items to [X.X.X] for releases\n- Script is now available for users to download\n\nWould you like me to create a version tag and update CHANGELOG for release?",
-    "onV2Merge": "✅ PR merged to v2 successfully (v2.0.0 development)\n✅ Branch cleaned up\n\n🔍 Status:\n- This is v2 development work - NOT yet released to users\n- v2 branch continues development\n- NO release tags created (v2 is still in progress)\n\nContinue with more v2 work or switch to v1 maintenance?"
+  "adapterContributions": {
+    "description": "v2.0.0 introduced extensible archive adapter system for backup formats",
+    "currentAdapters": ["duplicator"],
+    "futureAdapters": ["jetpack", "updraftplus", "backwpup", "all-in-one-wp-migration"],
+    "addingNewAdapter": [
+      "1. Read src/lib/adapters/README.md (comprehensive contributor guide)",
+      "2. Create new adapter file: src/lib/adapters/<format>.sh",
+      "3. Implement required functions (see base.sh for helpers):",
+      "   - detect_<format>_archive() - Format detection logic",
+      "   - validate_<format>_archive() - Archive validation",
+      "   - extract_<format>_archive() - Extraction to temp directory",
+      "   - find_<format>_database() - Locate SQL dump",
+      "   - find_<format>_wp_content() - Locate wp-content directory",
+      "4. Update Makefile to include new adapter in build",
+      "5. Add tests and documentation",
+      "6. Submit PR (see workflow below)"
+    ],
+    "adapterInterface": "See src/lib/adapters/README.md for complete specification"
+  },
+
+  "workflow": {
+    "description": "Standard workflow for all contributions (v2.0.0+)",
+    "baseBranch": "main",
+    "steps": [
+      "1. git checkout main && git pull --rebase origin main",
+      "2. git checkout -b <type>/<descriptive-slug>  (e.g., fix/url-validation, feature/jetpack-adapter)",
+      "3. Make changes in src/ directory (for code changes)",
+      "4. Run 'make build' to regenerate wp-migrate.sh",
+      "5. Run 'make test' to verify ShellCheck passes",
+      "6. Update CHANGELOG.md [Unreleased] section",
+      "7. git add -A && git commit -m 'type: description'",
+      "8. BEFORE pushing: git fetch origin main && check if main has new commits (git log HEAD..origin/main)",
+      "9. IF main has new commits: git merge origin/main, resolve conflicts, make build, git commit",
+      "10. git push origin <branch-name>",
+      "11. Create PR to main with 'gh pr create'",
+      "12. STOP and tell user: 'PR #X created at <URL>. Please review and approve before merging.'",
+      "13. WAIT FOR USER APPROVAL - do not merge",
+      "14. After user approves: gh pr merge <number>",
+      "15. Delete feature branch: git branch -d <branch-name> && git push origin --delete <branch-name>"
+    ],
+    "branchPrefixes": ["fix/", "feature/", "chore/", "docs/", "refactor/", "test/"],
+    "prTarget": "main",
+    "prApprovalRequired": "YES - NEVER MERGE WITHOUT USER APPROVAL",
+    "examples": [
+      "fix/maintenance-mode-cleanup → PR to main → USER APPROVES → merge → release",
+      "feature/jetpack-adapter → PR to main → USER APPROVES → merge → release"
+    ]
+  },
+
+  "multiPrStrategy": {
+    "note": "When multiple PRs are in flight (created but not yet merged):",
+    "problem": "If PR A merges before PR B, PR B's branch is now out of date and may have conflicts",
+    "prevention": [
+      "BEFORE creating any PR: Check if base branch has new commits since branch creation",
+      "BEFORE final push to PR: Sync with latest base branch",
+      "AFTER any PR merges to base: Immediately sync all open PR branches with base"
+    ],
+    "strategy": {
+      "description": "For PRs targeting main branch",
+      "onPrCreation": [
+        "1. git fetch origin main",
+        "2. Check: Are there commits on main since your branch was created?",
+        "3. If yes: git merge origin/main (or rebase if no conflicts expected)",
+        "4. Run make build && git add -A && git commit --amend --no-edit",
+        "5. Then create PR"
+      ],
+      "whenAnotherPrMerges": [
+        "1. git fetch origin main",
+        "2. git merge origin/main (resolve any conflicts)",
+        "3. Run make build to regenerate built files",
+        "4. Run make test to verify",
+        "5. git add -A && git commit -m 'Merge latest main branch'",
+        "6. git push"
+      ]
+    },
+    "proactiveMonitoring": "After completing work on your PR but BEFORE pushing, ALWAYS run: git fetch origin main && git log HEAD..origin/main to check if main has moved ahead"
+  },
+
+  "releaseProcess": {
+    "description": "Semantic versioning with GitHub releases",
+    "versioning": {
+      "major": "Breaking changes (e.g., v1.x.x → v2.0.0)",
+      "minor": "New features, backward compatible (e.g., v2.0.0 → v2.1.0)",
+      "patch": "Bug fixes (e.g., v2.1.0 → v2.1.1)"
+    },
+    "steps": [
+      "1. Update CHANGELOG.md: Move [Unreleased] items to [X.Y.Z] with date",
+      "2. git add CHANGELOG.md && git commit -m 'chore: release vX.Y.Z'",
+      "3. git push origin main",
+      "4. git tag vX.Y.Z -a -m 'vX.Y.Z - Brief description'",
+      "5. git push origin vX.Y.Z",
+      "6. gh release create vX.Y.Z --title 'vX.Y.Z - Title' --notes-file RELEASE_NOTES.md"
+    ],
+    "releaseNotes": "Include: summary, breaking changes (if any), new features, bug fixes, upgrade guide",
+    "changelogFormat": "Keep a Changelog (https://keepachangelog.com)"
   },
 
   "securityChecklist": {
@@ -249,53 +186,54 @@
       "perf": "Performance improvements",
       "style": "Code style changes (formatting, etc.)"
     },
-    "examples": {
-      "v1": [
-        "fix: prevent maintenance mode failure when wp-cli not found",
-        "feat: add --retry flag for network operations",
-        "docs: clarify --stellarsites flag usage"
-      ],
-      "v2": [
-        "refactor: split wp-migrate.sh into modular source files",
-        "feat: add Makefile build system",
-        "test: add bats-core unit tests for core functions"
-      ]
-    }
+    "examples": [
+      "fix: prevent maintenance mode failure when wp-cli not found",
+      "feat: add Jetpack Backup adapter",
+      "docs: update README with adapter contribution guide",
+      "refactor: extract common adapter logic to base.sh"
+    ]
   },
 
   "safetyReminders": {
     "beforeEveryGitOperation": [
-      "🚨 Did you ask the user: v1 or v2?",
-      "🚨 Does the branch name match the target? (v2-* → v2, others → main)",
-      "🚨 Are you following the correct workflow (workflow_v1 or workflow_v2)?",
-      "🚨 Will this PR target the correct branch?"
+      "🚨 Are you following the workflow from this settings file?",
+      "🚨 Does the branch name use conventional prefix (fix/, feature/, etc.)?",
+      "🚨 For src/ changes: Did you run 'make build'?",
+      "🚨 Will this PR target main branch?"
     ],
     "beforeCreatingPR": [
-      "🚨 CRITICAL: Has the base branch (main/v2) received new commits since I branched?",
-      "🚨 Run: git fetch origin <base> && git log HEAD..origin/<base>",
-      "🚨 If base has new commits: Merge them NOW before creating PR",
-      "🚨 This prevents merge conflicts and 'DIRTY' PR status"
+      "🚨 CRITICAL: Has main received new commits since I branched?",
+      "🚨 Run: git fetch origin main && git log HEAD..origin/main",
+      "🚨 If main has new commits: Merge them NOW before creating PR",
+      "🚨 This prevents merge conflicts and 'DIRTY' PR status",
+      "🚨 REMEMBER: After creating PR, STOP and WAIT for user approval"
+    ],
+    "afterCreatingPR": [
+      "🚨 DO NOT MERGE - Tell user: 'PR #X created at <URL>. Please review and approve before merging.'",
+      "🚨 WAIT for explicit user approval",
+      "🚨 User must say 'merge it', 'approve and merge', or similar",
+      "🚨 NEVER merge on your own initiative"
     ],
     "whenPRBlocked": [
       "If GitHub shows 'DIRTY' or 'CONFLICTING' status:",
       "1. Another PR merged after yours was created",
-      "2. Your branch is out of date with base branch",
-      "3. Solution: git merge origin/<base>, resolve conflicts, rebuild, push",
+      "2. Your branch is out of date with main",
+      "3. Solution: git merge origin/main, resolve conflicts, make build, git add -A, git commit, git push",
       "4. This creates a merge commit bringing both features together"
     ],
     "commonMistakes": [
-      "❌ Creating PR from v2-feature/* to main (should be to v2)",
-      "❌ Creating PR from fix/* to v2 (should be to main)",
-      "❌ Forgetting to ask user which version they're working on",
-      "❌ Using wrong branch prefix (fix/* when should be v2-fix/*)",
-      "❌ NOT checking if base branch has new commits before creating PR",
+      "❌ Editing wp-migrate.sh directly instead of src/ files",
+      "❌ Forgetting to run 'make build' after src/ changes",
+      "❌ Committing src/ changes without also committing built files",
+      "❌ Creating and merging PR without user approval (CRITICAL ERROR)",
+      "❌ NOT checking if main has new commits before creating PR",
       "❌ Ignoring that another PR was merged while working on yours"
     ]
   },
 
   "conflictPrevention": {
     "description": "How to prevent merge conflicts when multiple PRs are in flight",
-    "scenario": "You're working on PR B. PR A merges to base branch before you finish.",
+    "scenario": "You're working on PR B. PR A merges to main before you finish.",
     "symptoms": [
       "GitHub shows PR as 'DIRTY' or 'CONFLICTING'",
       "Merge button is disabled",
@@ -303,17 +241,18 @@
     ],
     "solution": {
       "immediate": [
-        "1. git fetch origin <base-branch>",
-        "2. git merge origin/<base-branch>",
+        "1. git fetch origin main",
+        "2. git merge origin/main",
         "3. Resolve any conflicts (both sets of changes should coexist)",
-        "4. For v2: Run 'make build' to regenerate wp-migrate.sh and checksum",
-        "5. git add -A && git commit -m 'Merge latest <base> branch'",
-        "6. git push",
-        "7. GitHub will now show PR as 'CLEAN' and 'MERGEABLE'"
+        "4. Run 'make build' to regenerate wp-migrate.sh and checksum",
+        "5. Run 'make test' to verify",
+        "6. git add -A && git commit -m 'Merge latest main branch'",
+        "7. git push",
+        "8. GitHub will now show PR as 'CLEAN' and 'MERGEABLE'"
       ],
       "prevention": [
-        "ALWAYS check before pushing: git fetch origin <base> && git log HEAD..origin/<base>",
-        "If base has moved ahead: Merge it BEFORE pushing your final commit",
+        "ALWAYS check before pushing: git fetch origin main && git log HEAD..origin/main",
+        "If main has moved ahead: Merge it BEFORE pushing your final commit",
         "Monitor open PRs: When any PR merges, sync your branch immediately"
       ]
     },

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS for wp-migrate.sh
+#
+# This file defines code ownership for the repository.
+# Code owners are automatically requested for review when someone opens a PR.
+#
+# Syntax: path/to/file @github-username
+# * matches everything in the repository
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @BWBama85
+
+# Critical files require owner review
+/wp-migrate.sh @BWBama85
+/src/** @BWBama85
+/Makefile @BWBama85
+/.github/** @BWBama85

--- a/RELEASE_NOTES_v2.0.0.md
+++ b/RELEASE_NOTES_v2.0.0.md
@@ -1,0 +1,226 @@
+# v2.0.0 - Modular Architecture + Extensible Archive Adapters
+
+**Release Date:** 2025-10-14
+
+This release represents a **major internal refactor** with minimal user-facing changes. The codebase has been restructured with a modular source layout and build system, making future development and contributions significantly easier. The archive import feature (formerly "Duplicator mode") has been redesigned with an extensible adapter architecture to support multiple backup formats.
+
+## Impact Summary
+
+- **User Impact:** Minimal - The `--duplicator-archive` flag still works (deprecated). Users continue downloading a single `wp-migrate.sh` file as before.
+- **Developer Impact:** Significant - Source code is now modular. Contributors must work with `src/` files and use `make build` to generate the single-file artifact.
+
+---
+
+## What's New
+
+### Archive Adapter System
+
+The biggest change is the new extensible adapter architecture for WordPress backup formats:
+
+- **Modular Format Support**: Each backup plugin format is handled by its own adapter module in `src/lib/adapters/`
+- **Auto-Detection**: Automatically detects archive formats (currently Duplicator; designed for Jetpack, UpdraftPlus, BackWPup, etc.)
+- **Manual Override**: New `--archive-type` flag for explicit format specification
+- **Easy Contribution**: Add new formats by creating a single adapter file (~100 lines) without modifying core code
+- **Comprehensive Guide**: See [src/lib/adapters/README.md](https://github.com/BWBama85/wp-migrate.sh/blob/main/src/lib/adapters/README.md) for contributor documentation
+
+### New Flags
+
+- **`--archive <path>`**: Replaces `--duplicator-archive` as the primary archive import flag. Supports any backup format via the adapter system.
+  ```bash
+  ./wp-migrate.sh --archive /backups/site.zip
+  ./wp-migrate.sh --archive /backups/site.zip --archive-type duplicator
+  ```
+
+### Modular Source Code (Developers)
+
+The codebase is now organized in a modular structure:
+
+```
+src/
+├── header.sh                # Shebang, defaults, variable declarations
+├── lib/
+│   ├── core.sh              # Core utilities (log, err, validate_url)
+│   ├── adapters/            # Archive format adapters
+│   │   ├── base.sh          # Shared adapter helper functions
+│   │   ├── duplicator.sh    # Duplicator adapter implementation
+│   │   └── README.md        # Contributor guide
+│   └── functions.sh         # All other functions
+└── main.sh                  # Argument parsing and execution
+```
+
+**Developer Workflow:**
+1. Edit files in `src/` (not `wp-migrate.sh` directly)
+2. Run `make build` to regenerate `wp-migrate.sh`
+3. Run `make test` to verify ShellCheck passes
+4. Commit both source files and built file
+
+**Makefile Targets:**
+- `make build` - Build the single-file script from modular source
+- `make test` - Run shellcheck on the complete built script
+- `make clean` - Remove build artifacts
+- `make help` - Show available targets
+
+---
+
+## Breaking Changes
+
+### For End Users
+**None.** The user-facing interface remains compatible with v1.x. The `--duplicator-archive` flag is deprecated but still functional.
+
+### For Developers
+- **MUST** work in `src/` files, not `wp-migrate.sh` directly
+- **MUST** run `make build` after any `src/` changes
+- **MUST** commit both source files and built file
+- **Internal variable names changed** (e.g., `DUPLICATOR_ARCHIVE` → `ARCHIVE_FILE`)
+- **Internal function names changed** (e.g., `extract_duplicator_archive()` → `extract_archive_to_temp()`)
+
+---
+
+## Upgrade Guide
+
+### For End Users
+
+**No action required.** Download the new version and use it exactly as before:
+
+```bash
+# Download v2.0.0
+curl -O https://raw.githubusercontent.com/BWBama85/wp-migrate.sh/main/wp-migrate.sh
+
+# Verify checksum
+curl -O https://raw.githubusercontent.com/BWBama85/wp-migrate.sh/main/wp-migrate.sh.sha256
+shasum -c wp-migrate.sh.sha256
+
+# Use as normal (all v1.x commands still work)
+./wp-migrate.sh --dest-host user@dest --dest-root /var/www/site
+./wp-migrate.sh --duplicator-archive /backups/site.zip  # Still works!
+```
+
+**Optional:** Start using the new `--archive` flag instead of `--duplicator-archive`:
+
+```bash
+# New style (recommended)
+./wp-migrate.sh --archive /backups/site.zip
+
+# Old style (deprecated but functional)
+./wp-migrate.sh --duplicator-archive /backups/site.zip
+```
+
+### For Contributors
+
+If you've contributed to v1.x, here's what changed:
+
+1. **Clone and setup:**
+   ```bash
+   git clone https://github.com/BWBama85/wp-migrate.sh.git
+   cd wp-migrate.sh
+   git checkout main
+
+   # Install pre-commit hook (recommended)
+   ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+   ```
+
+2. **Edit source files in `src/`, not `wp-migrate.sh`:**
+   ```bash
+   # Edit modular source
+   vim src/lib/functions.sh
+
+   # Build single-file script
+   make build
+
+   # Test with shellcheck
+   make test
+
+   # Commit both source and built files
+   git add src/lib/functions.sh wp-migrate.sh wp-migrate.sh.sha256
+   git commit -m "fix: improve error handling"
+   ```
+
+3. **Branch from main, PR to main:**
+   ```bash
+   git checkout -b fix/my-bugfix
+   # Make changes in src/
+   make build && make test
+   git add -A && git commit -m "fix: description"
+   git push origin fix/my-bugfix
+   # Open PR to main
+   ```
+
+---
+
+## Detailed Changes
+
+### Added
+- **Archive Adapter System**: Implemented extensible adapter architecture for supporting multiple WordPress backup formats. Currently ships with Duplicator adapter only; designed to support Jetpack, UpdraftPlus, BackWPup, and other formats in future releases. Each backup plugin format is handled by its own adapter module in `src/lib/adapters/`. Includes auto-detection of archive formats and manual override via `--archive-type` flag. Contributors can add new formats by creating a single adapter file without modifying core code (see `src/lib/adapters/README.md` for guide).
+- **New `--archive` flag**: Replaces `--duplicator-archive` as the primary archive import flag. Supports any backup format via the adapter system. Example: `--archive /path/to/backup.zip` with optional `--archive-type duplicator` for explicit format specification.
+- **Adapter contributor documentation**: Created comprehensive `src/lib/adapters/README.md` guide for adding new backup format support. Includes adapter interface specification, implementation examples, testing checklist, and common pitfalls to avoid.
+- **Duplicator adapter**: Moved all Duplicator-specific logic into `src/lib/adapters/duplicator.sh` as the first adapter implementation. Serves as reference implementation for future adapters.
+- **Base adapter helpers**: Created `src/lib/adapters/base.sh` with shared functions for archive detection, wp-content scoring, and format identification that all adapters can use.
+- **Modular source structure**: Organized codebase into `src/` directory (header.sh, lib/core.sh, lib/adapters/, lib/functions.sh, main.sh) for easier maintenance and code review.
+- **Makefile build system**: Added targets: `make build` (concatenate source files), `make test` (run shellcheck), `make clean` (remove build artifacts). Developers work in modular `src/` files and run `make build` to update the single-file `wp-migrate.sh` at repo root.
+- **Pre-commit git hook**: Added `.githooks/pre-commit` that prevents committing source changes without rebuilding `wp-migrate.sh` and `wp-migrate.sh.sha256`. Install with `ln -s ../../.githooks/pre-commit .git/hooks/pre-commit`.
+
+### Changed
+- **Renamed "Duplicator mode" to "archive mode"** throughout codebase. Migration mode is now detected as `MIGRATION_MODE="archive"` instead of `"duplicator"`. Log files now named `migrate-archive-import-*.log` instead of `migrate-duplicator-import-*.log`.
+- **Internal variable names changed**: `DUPLICATOR_ARCHIVE` → `ARCHIVE_FILE`, `DUPLICATOR_EXTRACT_DIR` → `ARCHIVE_EXTRACT_DIR`, `DUPLICATOR_DB_FILE` → `ARCHIVE_DB_FILE`, `DUPLICATOR_WP_CONTENT` → `ARCHIVE_WP_CONTENT`. User-facing `--duplicator-archive` flag maintained for backward compatibility.
+- **Internal function names changed**: `check_disk_space_for_duplicator()` → `check_disk_space_for_archive()`, `extract_duplicator_archive()` → `extract_archive_to_temp()`, `find_duplicator_database()` → `find_archive_database_file()`, `find_duplicator_wp_content()` → `find_archive_wp_content_dir()`, `cleanup_duplicator_temp()` → `cleanup_archive_temp()`.
+- **Updated Makefile** to include `src/lib/adapters/*.sh` files in build concatenation order. Build order: header → core → adapters (base, duplicator, ...) → functions → main.
+- **Updated help text** to reflect archive mode terminology and new `--archive` flag. Added examples for explicit format specification with `--archive-type`.
+- **Expanded README Development section** with detailed instructions for building from source, git hook setup, Makefile targets, and contribution guidelines for v2+ development.
+
+### Deprecated
+- `--duplicator-archive` flag deprecated in favor of `--archive`. Backward compatibility maintained - the old flag still works and is internally converted to `--archive --archive-type=duplicator`. Will be removed in v3.0.0.
+
+### Fixed
+- **HIGH**: Fixed preserve-dest-plugins broken in archive mode. After merge of preservation feature, code still referenced old variable name `DUPLICATOR_WP_CONTENT` instead of renamed `ARCHIVE_WP_CONTENT`. With `set -u` enabled, this caused immediate script abortion when using `--stellarsites` or `--preserve-dest-plugins` flags in archive mode.
+- **CRITICAL**: Fixed archive mode completely broken in single-file build. Removed dynamic `source` calls that tried to load adapter files at runtime (files don't exist in built artifact). The Makefile already concatenates all adapter code into the single `wp-migrate.sh` file, so these source calls were unnecessary and caused "No such file or directory" errors.
+- **HIGH**: Fixed cryptic "command not found" errors during adapter detection. Moved dependency checks before adapter detection logic. Previously, missing tools caused script to terminate with bare "command not found" before reaching the friendly "missing dependency" error. Now checks for `file` and `unzip` before attempting detection, providing clear installation instructions if missing.
+- **HIGH**: Fixed `set -e` causing silent exits with corrupt archives. Wrapped adapter function calls in `if !` blocks to capture non-zero exit status before `set -e` kills the script. Now properly displays user-friendly error explaining what went wrong.
+- **HIGH**: Fixed uncompressed TAR archives failing validation. Now uses appropriate flags based on archive type: `tar -tf` for uncompressed `.tar`, `tar -tzf` for `.tar.gz`. Enables future adapters supporting plain TAR backups.
+- **MEDIUM**: Updated README.md and CHANGELOG.md to accurately reflect currently supported formats. Changed documentation from promising "Duplicator, Jetpack, UpdraftPlus, etc." to stating "currently Duplicator only; designed to support additional formats in future releases." Prevents user confusion and "Unknown archive type" errors.
+- Made table prefix update failures fatal to prevent silent migration failures. If both `wp config set` and sed fallback fail to update the table prefix in wp-config.php, the script now aborts with a clear error message instead of continuing with a broken configuration.
+- Enhanced archive mode prefix detection fallback logic. When table prefix detection fails, the script now verifies that the assumed prefix is correct by querying the options table before continuing. Prevents silent failures where the script continues with an incorrect prefix assumption.
+
+---
+
+## Download
+
+Download the script:
+```bash
+curl -O https://raw.githubusercontent.com/BWBama85/wp-migrate.sh/main/wp-migrate.sh
+```
+
+Verify the checksum:
+```bash
+curl -O https://raw.githubusercontent.com/BWBama85/wp-migrate.sh/main/wp-migrate.sh.sha256
+shasum -c wp-migrate.sh.sha256
+```
+
+## Documentation
+
+- **README**: [README.md](https://github.com/BWBama85/wp-migrate.sh/blob/main/README.md)
+- **Changelog**: [CHANGELOG.md](https://github.com/BWBama85/wp-migrate.sh/blob/main/CHANGELOG.md)
+- **Adapter Guide**: [src/lib/adapters/README.md](https://github.com/BWBama85/wp-migrate.sh/blob/main/src/lib/adapters/README.md)
+
+## Contributing
+
+Contributions welcome! See the [Contributing](https://github.com/BWBama85/wp-migrate.sh#contributing) section in README.md for:
+- General contribution workflow
+- Adding new archive adapters (Jetpack, UpdraftPlus, etc.)
+- Build system usage
+
+---
+
+## What's Next?
+
+With the adapter system in place, we're looking to add support for additional WordPress backup formats:
+
+- **Jetpack Backup** (TAR format)
+- **UpdraftPlus** (multiple files)
+- **BackWPup** (archive format)
+- **All-in-One WP Migration** (wpress format)
+
+Contributors can add new formats by following the guide in [src/lib/adapters/README.md](https://github.com/BWBama85/wp-migrate.sh/blob/main/src/lib/adapters/README.md). Adding a new format is typically ~100 lines of code in a single file.
+
+---
+
+**Full Changelog**: [v1.1.8...v2.0.0](https://github.com/BWBama85/wp-migrate.sh/compare/v1.1.8...v2.0.0)


### PR DESCRIPTION
## Summary

Establishes code ownership and enforces PR approval workflow to prevent automated merges without explicit user review.

## Changes

### 1. `.github/CODEOWNERS`
- Defines @BWBama85 as owner for all repository files
- Critical files (wp-migrate.sh, src/, Makefile, .github/) explicitly listed
- Enables "Require review from Code Owners" branch protection
- Allows solo maintainer to approve own PRs while preventing automation

### 2. `.claude/settings.json` - Complete Rewrite
**Critical Addition: PR Approval Enforcement**
- Added prominent warning section at top of systemPrompt
- Explicit instructions: CREATE PR → STOP → WAIT FOR APPROVAL → MERGE
- Prohibits chaining `gh pr create && gh pr merge`
- Requires user to explicitly say "merge it" or "approve and merge"

**Workflow Updates:**
- Removed outdated v1/v2 dual-branch workflow
- Consolidated to single main branch workflow (post v2.0.0 merge)
- Updated for modular source structure with Makefile build system
- Added build system documentation and workflow
- Added adapter contribution guidelines

**Structure:**
- systemPrompt: PR approval enforcement + workflow basics
- projectContext: v2.0.0+ architecture, branches (main + v1-stable)
- buildSystem: Makefile workflow, source structure, warnings
- adapterContributions: Guide for adding new backup format adapters
- workflow: Standard contribution workflow with PR approval step
- multiPrStrategy: Conflict prevention for concurrent PRs
- releaseProcess: Semantic versioning + GitHub releases
- safetyReminders: Enhanced with "afterCreatingPR" section
- conflictPrevention: Merge conflict resolution strategies

### 3. `RELEASE_NOTES_v2.0.0.md`
- Complete v2.0.0 release notes (recreated after squash merge)
- Used to populate GitHub release

## Why This Matters

**Problem:** PR #28 was created and immediately merged without user approval, violating the established review workflow.

**Solution:** 
1. CODEOWNERS + "Require review from Code Owners" = technical enforcement
2. .claude/settings.json updates = explicit AI assistant instructions
3. Combined approach prevents both accidental and automated merges

## Next Steps (For User)

After merging this PR, update GitHub branch protection:

1. Go to: https://github.com/BWBama85/wp-migrate.sh/settings/rules
2. Edit "main" ruleset
3. Enable: **"Require review from Code Owners"**
4. Verify: Required approving review count = 1 (already set)

This allows you to approve your own PRs (as code owner) while preventing automation from merging without your explicit approval.

## Testing

- ✅ CODEOWNERS syntax validated
- ✅ settings.json is valid JSON
- ✅ All branch cleanup completed (chore/add-mit-license, v2-feature/preserve-dest-plugins deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)