### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2025-10-14
+
+**🚀 Second Archive Format: Jetpack Backup Support**
+
+This release adds Jetpack Backup as the second supported archive format, demonstrating the extensible adapter system working as designed. Users can now import both Duplicator and Jetpack Backup archives with automatic format detection.
+
 ### Added
 - **Jetpack Backup adapter**: Added support for Jetpack Backup archives (ZIP, TAR.GZ, or extracted directory format). Handles Jetpack's multi-file SQL structure (one table per file in `sql/` directory) by consolidating into a single database dump before import. Auto-detects Jetpack backups via `meta.json` signature file and `sql/wp_options.sql` presence. Supports both archive files and already-extracted directory paths. Table prefix detection extracts from SQL filenames (e.g., `wp_options.sql` → `wp_`). wp-content location detected at root level of backup. Example: `./wp-migrate.sh --archive /path/to/jetpack-backup.tar.gz` or `./wp-migrate.sh --archive /path/to/extracted-jetpack-backup/`.
 


### PR DESCRIPTION
## Summary

Prepares v2.1.0 release with Jetpack Backup adapter support.

This is a **minor version bump** (v2.0.0 → v2.1.0) following semantic versioning:
- **New feature**: Jetpack Backup adapter (backward compatible)
- **No breaking changes**: All existing functionality preserved
- **Duplicator support**: Unchanged and fully functional

## What's New in v2.1.0

### Jetpack Backup Adapter
Second supported archive format, demonstrating the extensible adapter architecture working as designed.

**Features:**
- Supports ZIP, TAR.GZ, and extracted directory formats
- Handles Jetpack's unique multi-file SQL structure (one table per file)
- Consolidates 60+ SQL files into single database dump for import
- Auto-detects via `meta.json` + `sql/wp_options.sql` signature
- Extracts table prefix from SQL filenames (e.g., `wp_options.sql` → `wp_`)
- Locates wp-content at root level of backup

**Usage:**
```bash
# Auto-detect format
./wp-migrate.sh --archive /backups/jetpack-backup.tar.gz

# Explicit format
./wp-migrate.sh --archive /backups/backup.zip --archive-type jetpack

# Works with extracted directories
./wp-migrate.sh --archive /path/to/extracted-jetpack-backup/
```

### Cross-Platform Compatibility
All fixes ensure Jetpack adapter works on:
- ✅ Linux (GNU tools)
- ✅ macOS (Bash 3.2, BSD tools)
- ✅ BSD systems

### Fixes
- **HIGH**: tar dependency check (prevents "command not found" during detection)
- **HIGH**: BSD sort compatibility (replaced `sort -z` with portable approach)
- **HIGH**: Bash 3.2 mapfile workaround (macOS default shell)
- **MEDIUM**: Hidden files preservation (`.htaccess`, `.user.ini`)
- **MEDIUM**: Documentation updates (README, help text)

## Changes

### CHANGELOG.md
- Converted `[Unreleased]` section → `[2.1.0] - 2025-10-14`
- Added release header with context
- Documented all Jetpack adapter features and fixes

### Documentation (Already Merged in PR #30)
- README.md: Updated to show both Duplicator and Jetpack support
- Help text: Reflects both archive formats
- Examples: Show usage for both formats

## Testing

**From PR #30 (merged):**
- ✅ `make build` passes
- ✅ ShellCheck clean (0 warnings)
- ✅ No GNU-specific commands
- ✅ Bash 3.2 compatible
- ✅ BSD/macOS compatible

**User testing pending:** Real-world Jetpack backup import

## Post-Merge Actions

After this PR merges:
1. Tag v2.1.0
2. Create GitHub Release with release notes
3. User tests with real Jetpack backup

## Related

- PR #30: Jetpack adapter implementation
- PR #28: v2.0.0 (modular architecture + adapter system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)