### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2025-10-15
+
+**🔌 Third Archive Format + Critical Bug Fix**
+
+This minor release adds support for Solid Backups (formerly BackupBuddy) archives and fixes a critical syntax error that prevented the script from running since v2.2.0.
+
 ### Added
-- **Solid Backups adapter**: Added support for Solid Backups (formerly BackupBuddy/iThemes Backup) archive format. Handles ZIP archives containing full WordPress installation with split database files in `wp-content/uploads/backupbuddy_temp/{BACKUP_ID}/`. Database is stored as multiple SQL files (one per table) which are automatically consolidated during import. Signature detection via `importbuddy.php` and `backupbuddy_dat.php` files.
+- **Solid Backups adapter**: Added support for Solid Backups (formerly BackupBuddy/iThemes Backup) archive format. Handles ZIP archives containing full WordPress installation with split database files in `wp-content/uploads/backupbuddy_temp/{BACKUP_ID}/`. Database is stored as multiple SQL files (one per table) which are automatically consolidated during import. Signature detection via `importbuddy.php` and `backupbuddy_dat.php` files. Custom table prefix support using `*.sql` pattern matching. Updated all CLI error messages and help text to include Solid Backups guidance. Three archive formats now supported: Duplicator, Jetpack Backup, and Solid Backups.
 
 ### Fixed
-- **Critical: Dependency error message syntax error**: Fixed bash syntax error in `needs()` function that prevented dependency error messages from displaying. The issue was caused by multi-line strings inside `echo` commands within a case statement inside command substitution `$(...)`. Refactored to extract installation instructions into separate `get_install_instructions()` helper function using heredocs. Script now properly displays installation instructions when dependencies (wp-cli, rsync, ssh, gzip, unzip, tar, file) are missing. Bug introduced in v2.2.0 (PR #38).
+- **Critical: Dependency error message syntax error**: Fixed bash syntax error in `needs()` function that prevented the script from running at all. The issue was caused by multi-line strings inside `echo` commands within a case statement inside command substitution `$(...)`. Refactored to extract installation instructions into separate `get_install_instructions()` helper function using heredocs. Script now properly displays installation instructions when dependencies (wp-cli, rsync, ssh, gzip, unzip, tar, file) are missing. Bug introduced in v2.2.0 (PR #38).
 
 ## [2.2.0] - 2025-10-14
 


### PR DESCRIPTION
## Release v2.3.0

This PR updates the CHANGELOG to release v2.3.0.

## What's New in v2.3.0

**🔌 Third Archive Format + Critical Bug Fix**

### Added
- **Solid Backups adapter**: New archive format support for Solid Backups (formerly BackupBuddy/iThemes Backup)
  - Handles ZIP archives with split SQL files in `backupbuddy_temp/{BACKUP_ID}/`
  - Custom table prefix support (not just `wp_`)
  - Auto-consolidates multiple SQL files during import
  - Three formats now supported: Duplicator, Jetpack, Solid Backups

### Fixed  
- **Critical syntax error**: Fixed bash syntax error that completely broke the script since v2.2.0
  - Script would not run at all due to parsing error in `needs()` function
  - Refactored dependency error messages to use helper function with heredocs
  - All dependency checks now work properly

## Changes

- Updated CHANGELOG.md to move [Unreleased] items to [2.3.0] with today's date (2025-10-15)

## Next Steps After Merge

1. Tag the release: `git tag v2.3.0 -a -m 'v2.3.0 - Third Archive Format + Critical Bug Fix'`
2. Push the tag: `git push origin v2.3.0`
3. Create GitHub release with release notes