### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2025-10-15
+
+**⚡ Faster Migrations: Optional Search-Replace**
+
+This minor release adds the `--no-search-replace` flag for faster migrations when bulk URL replacement isn't needed.
+
 ### Added
-- **--no-search-replace flag**: Added `--no-search-replace` flag to skip bulk search-replace operations while still updating home and siteurl options. Useful for faster migrations when you only need the site to load at the destination URL but don't need to replace URLs in post content, metadata, or other options. When flag is set, only the home and siteurl WordPress options are updated to destination URLs; all other content remains unchanged. The script logs a clear warning about this behavior and provides the manual wp search-replace command if needed later. Works in both push mode (direct migration) and archive mode (backup restore). Use cases: quick staging deployments, content migrations where URLs in posts don't matter, or situations where you'll run custom search-replace later.
+- **--no-search-replace flag**: Added `--no-search-replace` flag to skip bulk search-replace operations while still updating home and siteurl options. Useful for faster migrations when you only need the site to load at the destination URL but don't need to replace URLs in post content, metadata, or other options. When flag is set, only the home and siteurl WordPress options are updated to destination URLs; all other content remains unchanged. The script logs a clear warning about this behavior and provides the manual wp search-replace command if needed later. Works in both push mode (direct migration) and archive mode (backup restore). Dry-run preview accurately reflects the flag's behavior. Use cases: quick staging deployments, content migrations where URLs in posts don't matter, or situations where you'll run custom search-replace later.
 
 ## [2.3.0] - 2025-10-15
 


### PR DESCRIPTION
## Release v2.4.0

**⚡ Faster Migrations: Optional Search-Replace**

This minor release adds the `--no-search-replace` flag for faster migrations when bulk URL replacement isn't needed.

## Changes

### Added
- **--no-search-replace flag**: Skip bulk search-replace operations while still updating home and siteurl options
  - Useful for faster migrations when you only need the site to load at the destination URL
  - Only home and siteurl WordPress options are updated to destination URLs
  - All other content (post content, metadata, options) remains unchanged
  - Script logs clear warning and provides manual search-replace command if needed
  - Works in both push mode and archive mode
  - Dry-run preview accurately reflects the flag's behavior

## Use Cases

- Quick staging deployments (faster without bulk search-replace)
- Content migrations where URLs in posts don't matter
- Situations where custom search-replace will run later

## Release Checklist

- [x] CHANGELOG.md updated with v2.4.0 and date
- [ ] PR approved and merged to main
- [ ] Git tag v2.4.0 created
- [ ] GitHub release published

🤖 Generated with [Claude Code](https://claude.com/claude-code)