### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2025-10-16
+
+**🐛 Bug Fix: StellarSites Push Mode**
+
+This patch release fixes a critical bug where the `--stellarsites` flag didn't work correctly in push mode.
+
 ### Fixed
 - **--stellarsites flag in push mode**: Fixed `--stellarsites` flag to properly exclude `mu-plugins/` directory and `mu-plugins.php` loader file in push mode. Previously, the flag only worked correctly in archive mode. In push mode, it would auto-enable `--preserve-dest-plugins` but fail to exclude the protected mu-plugins files, causing rsync to attempt overwriting them and triggering permission errors on managed hosts. Now both push and archive modes correctly exclude mu-plugins files when `--stellarsites` is set, matching the documented behavior of "Works in both push and archive modes."
 


### PR DESCRIPTION
## Release v2.4.1

**🐛 Bug Fix: StellarSites Push Mode**

This patch release fixes a critical bug where the `--stellarsites` flag didn't work correctly in push mode.

## Changes

### Fixed
- **--stellarsites flag in push mode**: The flag now properly excludes `mu-plugins/` directory and `mu-plugins.php` loader file in push mode
  - Previously only worked in archive mode
  - In push mode, would auto-enable `--preserve-dest-plugins` but fail to exclude protected mu-plugins
  - Caused rsync permission errors on managed hosts (like StellarSites)
  - Now both modes correctly exclude mu-plugins files
  - Matches documented behavior: "Works in both push and archive modes"

## Impact

**Before (Broken):**
```bash
# Push mode with --stellarsites would fail:
rsync: [sender] delete_file: rmdir(mu-plugins/stellarsites-cloud) failed: Permission denied
```

**After (Fixed):**
```bash
# Push mode with --stellarsites now works correctly:
StellarSites mode: Preserving destination mu-plugins directory and loader
  Excluding: mu-plugins/ mu-plugins.php (StellarSites protected files)
```

## Release Checklist

- [x] CHANGELOG.md updated with v2.4.1 and date
- [ ] PR approved and merged to main
- [ ] Git tag v2.4.1 created
- [ ] GitHub release published

🤖 Generated with [Claude Code](https://claude.com/claude-code)