### PR TITLE
chore: release v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.2] - 2025-10-16
+
+**🚨 Critical Bug Fix: StellarSites mu-plugins Restoration**
+
+This patch release fixes a critical bug introduced in v2.4.1 where excluded mu-plugins files were never restored from backup in push mode, leaving StellarSites environments completely broken.
+
 ### Fixed
-- **CRITICAL: --stellarsites mu-plugins restoration in push mode**: Fixed critical bug where excluded mu-plugins files were never restored from backup in push mode, leaving StellarSites environments completely broken after migration. Push mode moves wp-content to backup, then rsync creates new wp-content with `--exclude=/mu-plugins/`. Previously, the excluded files stayed in the backup and were never copied back, resulting in missing `mu-plugins/` directory and `mu-plugins.php` loader file. Now properly restores both from backup after rsync completes, ensuring managed hosting environments have their required system plugins.
+- **CRITICAL: --stellarsites mu-plugins restoration in push mode**: Fixed critical bug where excluded mu-plugins files were never restored from backup in push mode, leaving StellarSites environments completely broken after migration. Push mode moves wp-content to backup, then rsync creates new wp-content with `--exclude=/mu-plugins/`. Previously, the excluded files stayed in the backup and were never copied back, resulting in missing `mu-plugins/` directory and `mu-plugins.php` loader file. Now properly restores both from backup after rsync completes, ensuring managed hosting environments have their required system plugins. Also fixed logging to only show success messages when restoration actually succeeds (not when it fails).
 
 ## [2.4.1] - 2025-10-16
 


### PR DESCRIPTION
## Release v2.4.2

**🚨 Critical Bug Fix: StellarSites mu-plugins Restoration**

This patch release fixes a critical bug introduced in v2.4.1 where excluded mu-plugins files were never restored from backup in push mode.

## The Bug (Introduced in v2.4.1)

v2.4.1 added rsync exclusions for mu-plugins but forgot to restore them:
1. ✅ Backup wp-content with `mv` (contains mu-plugins)
2. ✅ rsync creates new wp-content with `--exclude=/mu-plugins/`
3. ❌ **BUG**: mu-plugins stayed in backup, never restored
4. ❌ **Result**: Destination had NO mu-plugins - sites broken!

## Impact

- Missing `mu-plugins/` directory (e.g., stellarsites-cloud/)
- Missing `mu-plugins.php` loader file
- **StellarSites sites completely broken** after migration
- Required system plugins unavailable

## The Fix

Added restoration logic after rsync:
- Restores `mu-plugins/` directory from backup
- Restores `mu-plugins.php` loader file from backup
- Only logs success when restoration actually succeeds
- Includes error handling and warnings

## Changes

**Fixed:**
- mu-plugins restoration in push mode (lines 763-789)
- Conditional success logging (only on successful cp)

## Release Checklist

- [x] CHANGELOG.md updated with v2.4.2 and date
- [ ] PR approved and merged to main
- [ ] Git tag v2.4.2 created
- [ ] GitHub release published

🤖 Generated with [Claude Code](https://claude.com/claude-code)