### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2025-10-21
+
+**📦 Archive Format Support**
+
+This minor release adds support for Solid Backups NextGen archives, the completely rewritten successor to Solid Backups Legacy.
+
 ### Added
-- **Solid Backups NextGen adapter**: Full support for Solid Backups NextGen archives, the completely rewritten successor to Solid Backups Legacy. NextGen uses a different archive structure (database in `data/` directory instead of `wp-content/uploads/backupbuddy_temp/`, WordPress files in `files/` directory, metadata in `meta/` directory). Both Solid Backups Legacy and NextGen are now supported with separate adapters. Archive format is auto-detected based on structure.
+- **Solid Backups NextGen adapter**: Full support for Solid Backups NextGen archives with completely different structure from Legacy. NextGen stores database in top-level `data/` directory (not `wp-content/uploads/backupbuddy_temp/`), WordPress files in `files/` directory, and metadata in `meta/` directory. Both Solid Backups Legacy and NextGen are now supported with separate adapters (`solidbackups` and `solidbackups_nextgen`). Archive format is auto-detected based on structure, or specify explicitly with `--archive-type solidbackups_nextgen`. Adapter uses depth-first candidate iteration to reliably find correct `data/` and `files/` directories even when WordPress core/plugins contain nested directories with same names (e.g., `wp-includes/ID3/data`, `jetpack/tests/data`). Includes multisite support with `files/subdomains/` structure detection.
 
 ## [2.6.0] - 2025-10-20
 


### PR DESCRIPTION
## Summary
- Prepare v2.7.0 release with Solid Backups NextGen adapter support
- Update CHANGELOG.md to move [Unreleased] changes to [2.7.0] - 2025-10-21
- Release includes new archive format adapter for Solid Backups NextGen

## Release Notes

**v2.7.0 - Archive Format Support**

This minor release adds support for Solid Backups NextGen archives, the completely rewritten successor to Solid Backups Legacy.

### What's New
- **Solid Backups NextGen adapter**: Full support for NextGen archive format with:
  - Database in `data/` directory (not `wp-content/uploads/backupbuddy_temp/`)
  - WordPress files in `files/` directory
  - Metadata in `meta/` directory
  - Auto-detection based on structure
  - Explicit specification via `--archive-type solidbackups_nextgen`
  - Robust depth-first candidate iteration (handles nested data/files dirs)
  - Multisite support with `files/subdomains/` structure

### Version Bump
- **Previous**: v2.6.0
- **New**: v2.7.0 (minor bump per semantic versioning - new functionality added)

## Testing
- [x] CHANGELOG.md updated with release date
- [x] Version follows semantic versioning
- [x] All changes from PR #63 are documented

## Next Steps After Merge
1. Merge this PR to main
2. Create git tag: `git tag v2.7.0`
3. Push tag: `git push --tags`
4. GitHub Actions will create the release automatically

## Checklist
- [x] Branch follows `chore/*` naming convention
- [x] Commit message follows convention
- [x] CHANGELOG.md updated with release version and date
- [x] Release summary clearly describes changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)