### PR TITLE
fix: Correct array_diff bad substitution error with --stellarsites

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -612,8 +612,8 @@ if $PRESERVE_DEST_PLUGINS; then
 
   log_verbose "  Computing unique destination items (not in source)..."
   # Compute unique destination items (not in source)
-  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE[@] SOURCE_PLUGINS[@]
-  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE[@] SOURCE_THEMES[@]
+  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE SOURCE_PLUGINS
+  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE SOURCE_THEMES
 
   if ! $DRY_RUN; then
     log "  Destination has ${#DEST_PLUGINS_BEFORE[@]} plugin(s), source has ${#SOURCE_PLUGINS[@]} plugin(s)"
@@ -1126,8 +1126,8 @@ if $PRESERVE_DEST_PLUGINS; then
 
   log_verbose "  Computing unique destination items (not in archive)..."
   # Compute unique destination items (not in source/archive)
-  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE[@] SOURCE_PLUGINS[@]
-  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE[@] SOURCE_THEMES[@]
+  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE SOURCE_PLUGINS
+  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE SOURCE_THEMES
 
   if ! $DRY_RUN; then
     log "  Destination has ${#DEST_PLUGINS_BEFORE[@]} plugin(s), archive has ${#SOURCE_PLUGINS[@]} plugin(s)"

--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -4149,8 +4149,8 @@ if $PRESERVE_DEST_PLUGINS; then
 
   log_verbose "  Computing unique destination items (not in source)..."
   # Compute unique destination items (not in source)
-  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE[@] SOURCE_PLUGINS[@]
-  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE[@] SOURCE_THEMES[@]
+  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE SOURCE_PLUGINS
+  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE SOURCE_THEMES
 
   if ! $DRY_RUN; then
     log "  Destination has ${#DEST_PLUGINS_BEFORE[@]} plugin(s), source has ${#SOURCE_PLUGINS[@]} plugin(s)"
@@ -4663,8 +4663,8 @@ if $PRESERVE_DEST_PLUGINS; then
 
   log_verbose "  Computing unique destination items (not in archive)..."
   # Compute unique destination items (not in source/archive)
-  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE[@] SOURCE_PLUGINS[@]
-  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE[@] SOURCE_THEMES[@]
+  array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE SOURCE_PLUGINS
+  array_diff UNIQUE_DEST_THEMES DEST_THEMES_BEFORE SOURCE_THEMES
 
   if ! $DRY_RUN; then
     log "  Destination has ${#DEST_PLUGINS_BEFORE[@]} plugin(s), archive has ${#SOURCE_PLUGINS[@]} plugin(s)"

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-4f6e4677703e63dc2ad65f85c032befc773bb8167ac94ef82fab87ef3ee83cd8  wp-migrate.sh
+e6c5f4aef99927cbd3aa2b1e58b48a062066d473aedd08d8df192c77e8f9641c  wp-migrate.sh


### PR DESCRIPTION
## Problem

Using `--stellarsites` or `--preserve-dest-plugins` flags during archive import resulted in a "bad substitution" error:

```
./wp-migrate.sh: line 2678: ${DEST_PLUGINS_BEFORE[@][@]}: bad substitution
```

## Root Cause

The `array_diff` function expects plain array names as parameters, but was being called with the `[@]` suffix included:

```bash
array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE[@] SOURCE_PLUGINS[@]
```

When `array_diff` internally runs:
```bash
eval "local arr1_items=(\"\${${arr1_name}[@]}\")"
```

If `arr1_name` is `DEST_PLUGINS_BEFORE[@]`, this becomes invalid syntax:
```bash
eval "local arr1_items=(\"\${DEST_PLUGINS_BEFORE[@][@]}\")"
```

## Solution

Fixed all 4 calls to `array_diff` to use plain array names:

**Before:**
```bash
array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE[@] SOURCE_PLUGINS[@]
```

**After:**
```bash
array_diff UNIQUE_DEST_PLUGINS DEST_PLUGINS_BEFORE SOURCE_PLUGINS
```

The function itself handles the `[@]` expansion internally via eval.

## Testing

✅ ShellCheck validation passed  
✅ Build successful  
✅ Fixes error reported in user testing

## Impact

- Fixes crash when using `--stellarsites` flag
- Fixes crash when using `--preserve-dest-plugins` flag  
- Affects both push mode and archive mode plugin/theme preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)