### PR TITLE
chore: release v2.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.3] - 2025-11-25
+
+### Security
+
+- **Plain .tar archive Zip Slip validation**: Fixed security bypass where uncompressed `.tar` archives skipped path traversal validation entirely. The `validate_archive_paths()` function now properly detects and validates plain tar files using `tar -tf` in addition to compressed archives.
+
 ### Added
 
 - **Progress feedback for large archive extraction**: Archives over 500MB now display a message indicating extraction may take several minutes, with elapsed time logged upon completion. Uses `pv` with progress bar when available, otherwise falls back to status messages.
+- **Plain .tar archive support for Jetpack**: Restored support for uncompressed `.tar` Jetpack backup archives that was accidentally removed during refactoring.
+- **New security tests**: Added 3 tests for plain `.tar` archive validation (20 total Zip Slip tests).
 
 ### Changed
 
-- **Refactored adapter extraction code**: Consolidated duplicate extraction logic from all adapters into shared `adapter_base_extract_zip()` and `adapter_base_extract_tar_gz()` helper functions in `base.sh`, reducing code duplication and ensuring consistent progress feedback across all backup formats.
+- **Refactored adapter extraction code**: Consolidated duplicate extraction logic from all adapters into shared helper functions (`adapter_base_extract_zip()`, `adapter_base_extract_tar_gz()`, `adapter_base_extract_tar()`) in `base.sh`, reducing code duplication and ensuring consistent progress feedback across all backup formats.
 
 ## [2.10.2] - 2025-11-25
 

--- a/src/header.sh
+++ b/src/header.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-VERSION="2.10.2"  # wp-migrate version
+VERSION="2.10.3"  # wp-migrate version
 
 # -------------------------------------------------------------------
 # WordPress wp-content migration (PUSH mode) + DB dump transfer

--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-VERSION="2.10.2"  # wp-migrate version
+VERSION="2.10.3"  # wp-migrate version
 
 # -------------------------------------------------------------------
 # WordPress wp-content migration (PUSH mode) + DB dump transfer

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-d5f2a48ab6022d8e110326dde8ce0f956bf1e53f5020e18c90385ca4a4bff44e  wp-migrate.sh
+1a95497a28da753665f0be5271db905d0ae9f587ebd9ff24a242fc378ecdf6b7  wp-migrate.sh


### PR DESCRIPTION
## Summary

Release v2.10.3 with security fix and improvements from PR #108.

### Security

- **Plain .tar archive Zip Slip validation**: Fixed security bypass where uncompressed `.tar` archives skipped path traversal validation entirely

### Added

- **Progress feedback for large archive extraction**: Archives over 500MB now display size and duration warning
- **Plain .tar archive support for Jetpack**: Restored support accidentally removed during refactoring
- **New security tests**: 3 tests for plain `.tar` validation (20 total)

### Changed

- **Refactored adapter extraction code**: Consolidated duplicate logic into shared helpers

## Test plan

- [x] `make test` passes
- [x] All 20 Zip Slip security tests pass
- [x] Version updated to 2.10.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)