### PR TITLE
fix: auto-overwrite duplicate files during zip extraction

### DIFF
--- a/src/lib/adapters/base.sh
+++ b/src/lib/adapters/base.sh
@@ -135,19 +135,20 @@ adapter_base_extract_zip() {
     #   - --verbose or --trace is enabled (user wants to see details)
     #   - Large archives (>500MB) without quiet mode
     start_time=$(date +%s)
+    # -o: overwrite without prompting (archives may contain duplicates)
     if $VERBOSE || $TRACE_MODE || { [[ $archive_mb -gt 500 ]] && ! $QUIET_MODE; }; then
       if [[ $archive_mb -gt 500 ]]; then
         log "Extracting ${archive_mb}MB archive (this may take several minutes)..."
       fi
-      log_trace "unzip \"$archive\" -d \"$dest\""
+      log_trace "unzip -o \"$archive\" -d \"$dest\""
       # Show file-by-file progress (no -q flag)
-      if ! unzip "$archive" -d "$dest"; then
+      if ! unzip -o "$archive" -d "$dest"; then
         return 1
       fi
     else
       # Small archives in non-verbose mode: use quiet mode
-      log_trace "unzip -q \"$archive\" -d \"$dest\""
-      if ! unzip -q "$archive" -d "$dest" 2>/dev/null; then
+      log_trace "unzip -oq \"$archive\" -d \"$dest\""
+      if ! unzip -oq "$archive" -d "$dest" 2>/dev/null; then
         return 1
       fi
     fi

--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -544,19 +544,20 @@ adapter_base_extract_zip() {
     #   - --verbose or --trace is enabled (user wants to see details)
     #   - Large archives (>500MB) without quiet mode
     start_time=$(date +%s)
+    # -o: overwrite without prompting (archives may contain duplicates)
     if $VERBOSE || $TRACE_MODE || { [[ $archive_mb -gt 500 ]] && ! $QUIET_MODE; }; then
       if [[ $archive_mb -gt 500 ]]; then
         log "Extracting ${archive_mb}MB archive (this may take several minutes)..."
       fi
-      log_trace "unzip \"$archive\" -d \"$dest\""
+      log_trace "unzip -o \"$archive\" -d \"$dest\""
       # Show file-by-file progress (no -q flag)
-      if ! unzip "$archive" -d "$dest"; then
+      if ! unzip -o "$archive" -d "$dest"; then
         return 1
       fi
     else
       # Small archives in non-verbose mode: use quiet mode
-      log_trace "unzip -q \"$archive\" -d \"$dest\""
-      if ! unzip -q "$archive" -d "$dest" 2>/dev/null; then
+      log_trace "unzip -oq \"$archive\" -d \"$dest\""
+      if ! unzip -oq "$archive" -d "$dest" 2>/dev/null; then
         return 1
       fi
     fi

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-b1e8c6ba7398ea2c71af6b0eb17f274175f6a3b6c3cfe769603563a5f8a4daef  wp-migrate.sh
+765d845ccfffec3f070f3881f1391243c1d88a2b0721a2f7b74ff774b43b0cc3  wp-migrate.sh


### PR DESCRIPTION
## Summary

Archives may contain duplicate filenames (e.g., same image uploaded multiple times). Without the `-o` flag, unzip prompts interactively:

```
replace file.jpg? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

This causes the script to hang waiting for user input.

## Changes

- Add `-o` flag to all unzip commands to auto-overwrite duplicates
- Safe since we extract to a fresh temp directory

## Test plan

- [x] `make test` passes
- [x] All 20 Zip Slip security tests pass
- [ ] Test with archive containing duplicate filenames - should not prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)