### PR TITLE
chore: release v2.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.5] - 2025-11-26
+
+### Fixed
+
+- **Auto-overwrite duplicate files during zip extraction**: Archives containing duplicate filenames no longer cause the script to hang waiting for user input. Added `-o` flag to unzip commands to automatically overwrite duplicates.
+
 ## [2.10.4] - 2025-11-25
 
 ### Fixed

--- a/src/header.sh
+++ b/src/header.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-VERSION="2.10.4"  # wp-migrate version
+VERSION="2.10.5"  # wp-migrate version
 
 # -------------------------------------------------------------------
 # WordPress wp-content migration (PUSH mode) + DB dump transfer

--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-VERSION="2.10.4"  # wp-migrate version
+VERSION="2.10.5"  # wp-migrate version
 
 # -------------------------------------------------------------------
 # WordPress wp-content migration (PUSH mode) + DB dump transfer

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-765d845ccfffec3f070f3881f1391243c1d88a2b0721a2f7b74ff774b43b0cc3  wp-migrate.sh
+73debb9e6616de8a2fbe936667a64410031ee8aea720dcd0bf3206d56bd57dbb  wp-migrate.sh


### PR DESCRIPTION
## Summary

Release v2.10.5 with duplicate file handling fix from PR #112.

### Fixed

- **Auto-overwrite duplicate files during zip extraction**: Archives containing duplicate filenames no longer cause the script to hang waiting for user input.

## Test plan

- [x] `make test` passes
- [x] All 20 Zip Slip security tests pass
- [x] Version updated to 2.10.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)