### PR TITLE
fix: normalize extraction directory path in post-extraction validation

### DIFF
--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -2740,6 +2740,15 @@ Next steps:
   # SECURITY: Validate extracted files don't escape extraction directory (Zip Slip protection)
   log_verbose "Validating extracted file paths..."
   local extracted_file realpath_result validation_failed=false
+
+  # Normalize the extraction directory path (resolve symlinks, remove double slashes)
+  local normalized_extract_dir
+  if ! normalized_extract_dir=$(readlink -f "$ARCHIVE_EXTRACT_DIR" 2>/dev/null); then
+    if ! normalized_extract_dir=$(realpath "$ARCHIVE_EXTRACT_DIR" 2>/dev/null); then
+      normalized_extract_dir="$ARCHIVE_EXTRACT_DIR"
+    fi
+  fi
+
   while IFS= read -r -d '' extracted_file; do
     # Get absolute path, following symlinks
     if ! realpath_result=$(readlink -f "$extracted_file" 2>/dev/null); then
@@ -2751,7 +2760,9 @@ Next steps:
     fi
 
     # Check if resolved path is within extraction directory
-    if [[ "$realpath_result" != "$ARCHIVE_EXTRACT_DIR"* ]]; then
+    # Use trailing slash to ensure directory boundary match (prevents sibling dir attacks)
+    # e.g., /tmp/extract-123-malicious/file should NOT match /tmp/extract-123/
+    if [[ "$realpath_result" != "$normalized_extract_dir" && "$realpath_result" != "$normalized_extract_dir"/* ]]; then
       log_warning "SECURITY: Archive contains path outside extraction directory: $extracted_file"
       validation_failed=true
     fi

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-73debb9e6616de8a2fbe936667a64410031ee8aea720dcd0bf3206d56bd57dbb  wp-migrate.sh
+a841475f88c1b997d8fb9b1388a3c4bee19f24da31c89fe5f97189ad1e1105ee  wp-migrate.sh


### PR DESCRIPTION
## Summary

The post-extraction security check was triggering false positives for every extracted file due to path format mismatch.

**Problem:**
- `ARCHIVE_EXTRACT_DIR`: `/var/.../T//wp-migrate-archive-xxx` (contains double slash `//`)
- `realpath` result: `/var/.../T/wp-migrate-archive-xxx/...` (normalized single slash)

The string comparison `"$realpath_result" != "$ARCHIVE_EXTRACT_DIR"*` failed because the paths weren't equivalent strings, even though they pointed to the same directory.

**Fix:**
Normalize `ARCHIVE_EXTRACT_DIR` with `realpath`/`readlink` before comparing against extracted file paths.

## Test plan

- [x] `make test` passes
- [x] All 20 Zip Slip security tests pass
- [ ] Test with archive - should not show false positive warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)