### PR TITLE
chore: release v2.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.6] - 2025-11-26
+
+### Fixed
+
+- **False positive security warnings during extraction**: Fixed post-extraction path validation that incorrectly flagged all extracted files as "outside extraction directory" due to path format mismatch (double slash `//` vs normalized paths).
+
+### Security
+
+- **Sibling directory attack prevention**: Improved post-extraction validation to use directory boundary checking instead of naive prefix matching. Prevents attacks where `/tmp/extract-123-malicious/file` would incorrectly match `/tmp/extract-123`.
+
 ## [2.10.5] - 2025-11-26
 
 ### Fixed

--- a/src/header.sh
+++ b/src/header.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-VERSION="2.10.5"  # wp-migrate version
+VERSION="2.10.6"  # wp-migrate version
 
 # -------------------------------------------------------------------
 # WordPress wp-content migration (PUSH mode) + DB dump transfer

--- a/wp-migrate.sh
+++ b/wp-migrate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-VERSION="2.10.5"  # wp-migrate version
+VERSION="2.10.6"  # wp-migrate version
 
 # -------------------------------------------------------------------
 # WordPress wp-content migration (PUSH mode) + DB dump transfer

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-a841475f88c1b997d8fb9b1388a3c4bee19f24da31c89fe5f97189ad1e1105ee  wp-migrate.sh
+307e2fe6eefc71be66e73f33bf06931d7d871cbfa6eaad61a251642efedaa4e7  wp-migrate.sh


### PR DESCRIPTION
## Summary

Release v2.10.6 with path validation fixes from PR #114.

### Fixed

- **False positive security warnings during extraction**: Fixed post-extraction path validation that incorrectly flagged all extracted files as "outside extraction directory" due to path format mismatch.

### Security

- **Sibling directory attack prevention**: Improved post-extraction validation to use directory boundary checking instead of naive prefix matching.

## Test plan

- [x] `make test` passes
- [x] All 20 Zip Slip security tests pass
- [x] Version updated to 2.10.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)