### PR TITLE
fix: validate wp-content source before rsync and improve error handling

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -1853,9 +1853,45 @@ else
 
   # Sync wp-content from archive to destination
   # Excluded items (mu-plugins, object-cache.php) are preserved in destination
+
+  # Verify source directory exists and has content before rsync
+  if [[ ! -d "$ARCHIVE_WP_CONTENT" ]]; then
+    err "CRITICAL: Archive wp-content directory no longer exists: $ARCHIVE_WP_CONTENT
+
+The extracted wp-content directory was deleted or moved before rsync could run.
+This may indicate:
+  • macOS cleaned up the temp directory
+  • Another process modified the extraction directory
+  • Disk space issues caused cleanup
+
+The database has been imported but wp-content was NOT synced.
+To recover, restore from the backup: $DEST_WP_CONTENT_BACKUP"
+  fi
+
+  source_file_count=$(find "$ARCHIVE_WP_CONTENT" -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$source_file_count" -lt 10 ]]; then
+    err "CRITICAL: Archive wp-content directory appears empty or nearly empty ($source_file_count files)
+
+Expected thousands of files but found very few. This may indicate:
+  • Extraction failed silently
+  • Archive was corrupted
+  • Temp directory was partially cleaned
+
+The database has been imported but wp-content was NOT synced.
+To recover, restore from the backup: $DEST_WP_CONTENT_BACKUP"
+  fi
+
+  log_verbose "  Source file count: $source_file_count"
   log_trace "rsync ${RSYNC_OPTS[*]} ${RSYNC_EXCLUDES[*]} $ARCHIVE_WP_CONTENT/ $DEST_WP_CONTENT/"
-  rsync "${RSYNC_OPTS[@]}" "${RSYNC_EXCLUDES[@]}" \
-    "$ARCHIVE_WP_CONTENT/" "$DEST_WP_CONTENT/" | tee -a "$LOG_FILE"
+
+  # Run rsync and capture exit status (pipefail ensures we catch rsync failures)
+  if ! rsync "${RSYNC_OPTS[@]}" "${RSYNC_EXCLUDES[@]}" \
+    "$ARCHIVE_WP_CONTENT/" "$DEST_WP_CONTENT/" 2>&1 | tee -a "$LOG_FILE"; then
+    err "rsync failed to sync wp-content from archive.
+
+The database has been imported but wp-content sync failed.
+To recover, restore from the backup: $DEST_WP_CONTENT_BACKUP"
+  fi
 
   log "wp-content synced successfully (object-cache.php excluded to preserve destination caching)"
 

--- a/wp-migrate.sh.sha256
+++ b/wp-migrate.sh.sha256
@@ -1,1 +1,1 @@
-307e2fe6eefc71be66e73f33bf06931d7d871cbfa6eaad61a251642efedaa4e7  wp-migrate.sh
+6650612e6854c1af45c12786807f7b82edf247c20ba7e3cda0f9a48209ff9c7c  wp-migrate.sh


### PR DESCRIPTION
## Summary

- Add validation to ensure archive wp-content directory exists before rsync
- Add file count verification to catch empty/incomplete extractions
- Improve rsync error handling with explicit exit status checking
- Add detailed error messages with recovery instructions

This addresses an issue where wp-content failed to sync after database import, leaving the destination with only default plugins. The root cause was unclear, but these safeguards will catch and report such failures in the future.

## Test plan

- [ ] Run archive import with `--dry-run --verbose` to verify validation messages appear
- [ ] Test with valid archive to ensure normal operation unaffected
- [ ] Verify shellcheck passes: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)